### PR TITLE
Use default qname when no prefix is present

### DIFF
--- a/src/main/java/com/siemens/ct/exi/core/AbstractEXIBodyDecoder.java
+++ b/src/main/java/com/siemens/ct/exi/core/AbstractEXIBodyDecoder.java
@@ -292,7 +292,7 @@ public abstract class AbstractEXIBodyDecoder extends AbstractEXIBodyCoder
 	}
 
 	public String getAttributeQNameAsString() {
-		if (this.preservePrefix) {
+		if (this.preservePrefix && this.attributePrefix != null) {
 			return QNameUtilities.getQualifiedName(
 					attributeQNameContext.getLocalName(), this.attributePrefix);
 		} else {


### PR DESCRIPTION
In case the attribute has the same namespace as its element,
the attribute should inherit its default namspace, as done
by QNameContext.getDefaultQNameAsString();

This fixes #1.

Signed-off-by: Robert Varga nite@hq.sk
