### PR TITLE
Add OSGI header manifest and update java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
 
   <properties>
     <!-- maven-compiler-plugin configuration -->
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
   </properties>
 
 
@@ -88,7 +88,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version><!--2.3.2-->
+        <version>2.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -37,21 +37,14 @@
 
   <scm>
     <connection>scm:git:git://github.com/EXIficient/exificient-core.git</connection>
-	<!--<developerConnection>scm:git:git@github.com:EXIficient/exificient-core.git</developerConnection>-->
-	<developerConnection>scm:git:https://github.com/EXIficient/exificient-core.git</developerConnection>
+    <!--<developerConnection>scm:git:git@github.com:EXIficient/exificient-core.git</developerConnection>-->
+    <developerConnection>scm:git:https://github.com/EXIficient/exificient-core.git</developerConnection>
     <!--<url>https://github.com/EXIficient/exificient-core</url>-->
-	<url>https://github.com/EXIficient/exificient-core.git</url>
+    <url>https://github.com/EXIficient/exificient-core.git</url>
     <tag>HEAD</tag>
   </scm>
 
   <dependencies>
-    <!-- Runtime Dependencies (schema-informed mode) -->
-    <!--<dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <version>2.11.0</version>
-    </dependency>
-	-->
     <!-- Test Dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -65,22 +58,6 @@
       <version>1.6</version>
       <scope>test</scope>
     </dependency>
-	<!--
-    <dependency>
-      <groupId>org.codehaus.woodstox</groupId>
-      <artifactId>woodstox-core-asl</artifactId>
-      <version>4.1.2</version>
-      <scope>test</scope>
-    </dependency>
-	-->
-    <!-- Eclipse m2e -->
-    <!--
-	<dependency>
-		<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-resources-plugin</artifactId>
-		<version>2.5</version>
-	</dependency>
-	-->
   </dependencies>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>EXIficient-Core</name>
   <url>http://exificient.github.io/</url>
   <version>0.9.7-SNAPSHOT</version>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <description>EXIficient is an open source implementation of the W3C Efficient XML Interchange
     (EXI) format specification written in the Java programming language. The EXI format is a very
     compact representation for the Extensible Markup Language (XML) Information Set that is intended
@@ -70,6 +70,18 @@
   <build>
     <finalName>exificient-core</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+          </instructions>
+        </configuration>
+      </plugin>
       <!-- Include test classes -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
In the provided PR we updated to the current java 8 version. 
Because if you used eclipse with version 5 as defined in the pom. There are some errors. 

And we added the OSGI header, so it is possible to use exificient in a karaf + cxf environment.

